### PR TITLE
Update the documentation URL with new documentation repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
 					<p>Ginkgo supports execution on CUDA, HIP and SYCL accelerators, and OpenMP-enabled devices.</p>
 					<p>
 						<a class="btn btn-ginkgo-orange-1"
-							href="https://ginkgo-project.github.io/ginkgo/doc/develop/"
+							href="https://ginkgo-project.github.io/ginkgo-generated-documentation/doc/develop/"
 							target="_blank">Cross Platform</a>
 					</p>
 


### PR DESCRIPTION
The new link is here: https://ginkgo-project.github.io/ginkgo-generated-documentation/doc/develop/index.html